### PR TITLE
added EXPOSE 80 to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,7 @@ RUN npm run build
 
 # Run Stage
 FROM nginx
+# Elastic Beanstalk looks for Expose instruction and maps automatically
+EXPOSE 80
 COPY --from=buildStage /app/build /usr/share/nginx/html
 ## nginx automatically starts up


### PR DESCRIPTION
Elastic Beanstalk looks for Expose instruction and maps automatically to the port specified